### PR TITLE
05-pytest.md: fix example code block markup

### DIFF
--- a/05-pytest.md
+++ b/05-pytest.md
@@ -117,10 +117,9 @@ will print summary information.
 > test_mean.py .....
 >
 > ========================== 5 passed in 2.68 seconds ===========================
+> ~~~
 
 As we write more code, we would write more tests, and pytest would produce
 more dots.  Each passing test is a small, satisfying reward for having written
 quality scientific software. Now that you know how to write tests, let's go
 into what can go wrong.
-
-


### PR DESCRIPTION
This pull is a tiny change that adds a set of missing `~~~` at the end of a code block in chapter 5.

It looked like this:
![screenshot from 2016-12-08 23-59-08](https://cloud.githubusercontent.com/assets/3074453/21029897/8e9f0988-bda4-11e6-853c-0165666a682e.png)

On my local preview (`make clean preview && jekyll serve`) it looks like this:
![screenshot from 2016-12-08 23-57-22](https://cloud.githubusercontent.com/assets/3074453/21029891/8ba3ec6c-bda4-11e6-8db3-130e082e4071.png)

