### PR TITLE
Add discussion of some common Travis errors and fixes

### DIFF
--- a/08-ci.md
+++ b/08-ci.md
@@ -114,6 +114,9 @@ install:
 script: py.test
 ~~~
 
+However, the exact syntax is very important,
+[https://lint.travis-ci.org/](https://lint.travis-ci.org/)
+can be used to check for typographic errors.
 You can see how the python package manager, pip, will use your requirements.txt file
 from the previous exercise. That requirements.txt file is a conventional way to
 list all of the python packages that we need. If we needed pytest, numpy, and
@@ -131,6 +134,8 @@ pytest
 > 2. Commit and push it.
 > 3. Check the situation at [your server](https://travis-ci.org/)
 
+Some guidance on debugging problems if the tests fail to run can be found in
+the [lesson discussion document](./discussion.html).
 
 ## Continuous Integration Hosting
 

--- a/discussion.md
+++ b/discussion.md
@@ -9,7 +9,7 @@ subtitle: Discussion
 ### Why doesn't Travis-CI run my tests?
 
 A common problem in the [Continuous Integration](./08-ci.html) part of this 
-lesson is that Travis-CI does not run the tests in the version control
+lesson is that Travis-CI does not run the tests in the version-controlled
 repository. One thing to watch out for is that Travis-CI is *very* picky about
 the format of the `.travis.yaml` file, but other problems are also possible.
 Some of these, and how they can be fixed, are outlined below.
@@ -33,4 +33,4 @@ This should trigger the tests to run again.
 * The tests don't run at all. One reason for this is that Travis has not "seen"
 changes pushed to GitHub, for example if the configuration files are pushed
 before Travis is linked to the GitHub account. Try to fix this by making a 
-minor change to a file, the committing and pushing the change.
+minor change to a file, then committing and pushing the change.

--- a/discussion.md
+++ b/discussion.md
@@ -6,4 +6,31 @@ subtitle: Discussion
 
 ## Frequently Asked Questions
 
-?
+### Why doesn't Travis-CI run my tests?
+
+A common problem in the [Continuous Integration](./08-ci.html) part of this 
+lesson is that Travis-CI does not run the tests in the version control
+repository. One thing to watch out for is that Travis-CI is *very* picky about
+the format of the `.travis.yaml` file, but other problems are also possible.
+Some of these, and how they can be fixed, are outlined below.
+
+* The `.travis.yml` file is malformed. This results in an error message
+`ERROR: An error occured while trying to parse your .travis.yml file` and
+the test is recorded as "canceled". Try using
+[https://lint.travis-ci.org/](https://lint.travis-ci.org/).
+This should point to the line of the error and give a more useful error
+message. Try to fix the error, commit and push the fixed `.travis.yml` file,
+and push to GitHub to rerun the tests.
+
+* The tests fail with the message `The command "rake" exited with 1.` at the
+end of the log file. This indicates that Travis attempted to run the tests
+for software written in Ruby. This is the default for Travis and probably means
+that the `.travis.yaml` file has not been found. One reason for this may be
+that the first dot has been missed. Check with `ls -a` and if this is the case
+use the `git mv` command to rename the file, then `git commit` and `git push`.
+This should trigger the tests to run again.
+
+* The tests don't run at all. One reason for this is that Travis has not "seen"
+changes pushed to GitHub, for example if the configuration files are pushed
+before Travis is linked to the GitHub account. Try to fix this by making a 
+minor change to a file, the committing and pushing the change.


### PR DESCRIPTION
This addresses issue #10. I've added three things to the lesson:

1. A list three reasons why travisCI fails to run tests and
information on how to fix these to discussion.md. These
have all been seen in practice when delivering the lesson.

2. A note the use of https://lint.travis-ci.org/ in 08-ci and
note that the syntax is important.

3. A link from 08-ci to the discussion file, suggesting
that fixes for some errors can be found there.

I also thought about putting the advice in a "solution" div element under the "Add a .travis.yml File" challenge (as a "hint"). However, this is not hidden using the current template. It may be worth revisiting this once the template is updated.
